### PR TITLE
🐛(slice): fix slice index

### DIFF
--- a/ipx800/ipx800.py
+++ b/ipx800/ipx800.py
@@ -111,4 +111,5 @@ class Relay(IPX800):
         return f"<ipx800.relay id={self.id}>"
 
     def __str__(self) -> str:
-        return f"[IPX800-relay: id={self.id}, status={'On' if self.status else 'Off'}]"
+        return (f"[IPX800-relay: id={self.id}, "
+                f"status={'On' if self.status else 'Off'}]")

--- a/ipx800/ipx800.py
+++ b/ipx800/ipx800.py
@@ -85,6 +85,10 @@ class Relay(IPX800):
         response = self._request(params)
         return response[f"R{self.id}"] == 1
 
+    @property
+    def status_str(self) -> str:
+        return "On" if self.status() else "Off"
+
     def on(self) -> bool:
         """Turn on a relay and return True if it was successful."""
         params = {"SetR": self.id}
@@ -107,4 +111,4 @@ class Relay(IPX800):
         return f"<ipx800.relay id={self.id}>"
 
     def __str__(self) -> str:
-        return f"[IPX800-relay: id={self.id}, status={self.status}"
+        return f"[IPX800-relay: id={self.id}, status={'On' if self.status else 'Off'}]"

--- a/ipx800/ipx800.py
+++ b/ipx800/ipx800.py
@@ -85,10 +85,6 @@ class Relay(IPX800):
         response = self._request(params)
         return response[f"R{self.id}"] == 1
 
-    @property
-    def status_str(self) -> str:
-        return "On" if self.status() else "Off"
-
     def on(self) -> bool:
         """Turn on a relay and return True if it was successful."""
         params = {"SetR": self.id}

--- a/ipx800/ipx800.py
+++ b/ipx800/ipx800.py
@@ -58,7 +58,10 @@ class GenericSlice(collections.abc.Sequence):
                 for k in range(key.start, key.stop, key.step)
             ]
         elif isinstance(key, int):
-            return self._type(self._ipx, key + 1)
+            if key < self.__len__():
+                return self._type(self._ipx, key + 1)
+            else:
+                raise IndexError
         else:
             raise TypeError("Slice of 'int' is the only accepted range")
 

--- a/tests/setr2.json
+++ b/tests/setr2.json
@@ -1,0 +1,4 @@
+{
+    "product": "IPX800_V4",
+    "status": "Success"
+}

--- a/tests/test_ipx800.py
+++ b/tests/test_ipx800.py
@@ -29,7 +29,7 @@ class IPX800Test(TestCase):
     def test_invalid_relay_index(self):
         ipx = ipx800("http://192.0.2.4")
         with self.assertRaises(TypeError):
-            ipx.relays['abc']
+            ipx.relays["abc"]
 
     @patch("requests.get")
     def test_invalid_relay(self, mock_request):
@@ -121,7 +121,9 @@ class IPX800Test(TestCase):
 
         ipx = ipx800("http://192.0.2.4")
         self.assertEqual(str(ipx.relays[0]), "[IPX800-relay: id=1, status=On]")
-        self.assertEqual(str(ipx.relays[2]), "[IPX800-relay: id=3, status=Off]")
+        self.assertEqual(
+            str(ipx.relays[2]), "[IPX800-relay: id=3, status=Off]"
+        )
 
     @patch("requests.get")
     def test_relay_error(self, mock_request):

--- a/tests/test_ipx800.py
+++ b/tests/test_ipx800.py
@@ -26,6 +26,11 @@ class IPX800Test(TestCase):
                 mock_response.json.return_value = json.loads(f.read())
         return mock_response
 
+    def test_invalid_relay_index(self):
+        ipx = ipx800("http://192.0.2.4")
+        with self.assertRaises(TypeError):
+            ipx.relays['abc']
+
     @patch("requests.get")
     def test_invalid_relay(self, mock_request):
         mock_request.return_value = self._mock_response(
@@ -55,6 +60,14 @@ class IPX800Test(TestCase):
         self.assertEqual(len(ipx.relays), 56)
 
     @patch("requests.get")
+    def test_relay_iteration(self, mock_request):
+        mock_request.side_effect = [
+            self._mock_response(json_file="tests/getr.json") for i in range(56)
+        ]
+        ipx = ipx800("http://192.0.2.4")
+        self.assertEqual(len([r for r in ipx.relays]), 56)
+
+    @patch("requests.get")
     def test_relay_status(self, mock_request):
         mock_request.side_effect = [
             self._mock_response(json_file="tests/getr.json"),
@@ -77,6 +90,38 @@ class IPX800Test(TestCase):
 
         ipx = ipx800("http://192.0.2.4")
         assert ipx.relays[1].off()
+
+    @patch("requests.get")
+    def test_relay_on(self, mock_request):
+        mock_request.side_effect = [
+            self._mock_response(json_file="tests/getr.json"),
+            self._mock_response(json_file="tests/setr2.json"),
+        ]
+
+        ipx = ipx800("http://192.0.2.4")
+        assert ipx.relays[1].on()
+
+    @patch("requests.get")
+    def test_relay_toggle(self, mock_request):
+        mock_request.side_effect = [
+            self._mock_response(json_file="tests/getr.json"),
+            self._mock_response(json_file="tests/setr2.json"),
+        ]
+
+        ipx = ipx800("http://192.0.2.4")
+        assert ipx.relays[1].toggle()
+
+    @patch("requests.get")
+    def test_relay_str(self, mock_request):
+        mock_request.side_effect = [
+            self._mock_response(json_file="tests/getr.json"),
+            self._mock_response(json_file="tests/getr.json"),
+            self._mock_response(json_file="tests/getr.json"),
+        ]
+
+        ipx = ipx800("http://192.0.2.4")
+        self.assertEqual(str(ipx.relays[0]), "[IPX800-relay: id=1, status=On]")
+        self.assertEqual(str(ipx.relays[2]), "[IPX800-relay: id=3, status=Off]")
 
     @patch("requests.get")
     def test_relay_error(self, mock_request):

--- a/tests/test_ipx800.py
+++ b/tests/test_ipx800.py
@@ -34,7 +34,7 @@ class IPX800Test(TestCase):
 
         ipx = ipx800("http://192.0.2.4")
         with self.assertRaises(ApiError):
-            r999 = ipx.relays[998].status
+            ipx.relays[998].status
         self.assertIn(
             call(
                 "http://192.0.2.4/api/xdevices.json",

--- a/tests/test_ipx800.py
+++ b/tests/test_ipx800.py
@@ -33,9 +33,8 @@ class IPX800Test(TestCase):
         )
 
         ipx = ipx800("http://192.0.2.4")
-        r999 = ipx.relays[998]
         with self.assertRaises(ApiError):
-            r999.status
+            r999 = ipx.relays[998].status
         self.assertIn(
             call(
                 "http://192.0.2.4/api/xdevices.json",
@@ -61,6 +60,7 @@ class IPX800Test(TestCase):
             self._mock_response(json_file="tests/getr.json"),
             self._mock_response(json_file="tests/getr.json"),
             self._mock_response(json_file="tests/getr.json"),
+            self._mock_response(json_file="tests/getr.json"),
         ]
 
         ipx = ipx800("http://192.0.2.4")
@@ -70,9 +70,10 @@ class IPX800Test(TestCase):
 
     @patch("requests.get")
     def test_relay_off(self, mock_request):
-        mock_request.return_value = self._mock_response(
-            json_file="tests/clearr2.json"
-        )
+        mock_request.side_effect = [
+            self._mock_response(json_file="tests/getr.json"),
+            self._mock_response(json_file="tests/clearr2.json"),
+        ]
 
         ipx = ipx800("http://192.0.2.4")
         assert ipx.relays[1].off()


### PR DESCRIPTION
Fix _slice_ `IndexError` that should be raised at the end of the slice.