### PR TITLE
fix(ci): fix git dubious error msg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   eclint:
     runs-on: ubuntu-latest
-    container: greut/eclint:latest
+    container:
+      image: greut/eclint:latest
+      options: --user 1000:1000  # Due to git dubious ownership change
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,19 @@ jobs:
   eclint:
     runs-on: ubuntu-latest
     container:
-      image: greut/eclint:latest
-      options: --user 1000:1000  # Due to git dubious ownership change
+      image: ghcr.io/greut/eclint:latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
 
+      - name: fix git
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE:-$(pwd)}"
+
+      - name: eclint version
+        run: eclint -version
+
       - name: linting based on .editorconfig
-        run: eclint
+        run: eclint -color=always
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   eclint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/greut/eclint:latest
+      image: registry.gitlab.com/greut/eclint:latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
### What

Fixing the execution of `eclint` which relies on `git ls-files` returning an error due to the mismatch between the file owner and the shell user.

### Why

Getting this error during `eclint` execution:

```
E0122 16:45:39.395859       7 main.go:176]  "msg"="cannot list files" "error"="not a git repository: exit status 128" 
E0122 16:45:39.396031       7 main.go:127]  "msg"="linting failure" "error"="not a git repository: exit status 128" 
```

```
$ git ls-files
fatal: detected dubious ownership in repository at '/app'
To add an exception for this directory, call:

	git config --global --add safe.directory /app
```