### PR TITLE
fix: missing interpolation for off and toggle command

### DIFF
--- a/ipx800/ipx800.py
+++ b/ipx800/ipx800.py
@@ -101,13 +101,13 @@ class BaseSwitch(IPX800):
 
     def off(self) -> bool:
         """Turn off and return True if it was successful."""
-        params = {"Clear{self._code}": self.id}
+        params = {f"Clear{self._code}": self.id}
         self._request(params)
         return True
 
     def toggle(self) -> bool:
         """Toggle and return True if it was successful."""
-        params = {"Toggle{self._code}": self.id}
+        params = {f"Toggle{self._code}": self.id}
         self._request(params)
         return True
 


### PR DESCRIPTION
Fix a bug on the methods `off()` and `toggle()` for the relays with the missing interpolation to send the correct code.